### PR TITLE
Extended configuration mode and bug-fix

### DIFF
--- a/src/esp-fs-webserver.cpp
+++ b/src/esp-fs-webserver.cpp
@@ -130,8 +130,7 @@ bool FSWebServer::begin(const char *path)
 
 void FSWebServer::setCaptiveWebage(const char *url)
 {
-    m_apWebpage = (char *)realloc(m_apWebpage, sizeof(url));
-    strcpy(m_apWebpage, url);
+    m_apWebpage = url;
 }
 
 IPAddress FSWebServer::setAPmode(const char *ssid, const char *psk)

--- a/src/esp-fs-webserver.cpp
+++ b/src/esp-fs-webserver.cpp
@@ -33,12 +33,12 @@ bool FSWebServer::checkDir(const char *dirname)
         File root = m_filesystem->open(dirname, "r");
         if (!root)
         {
-            DebugPrintln("- failed to open directory\n");
+            DebugPrintln("- failed to open directory");
             return false;
         }
         if (!root.isDirectory())
         {
-            DebugPrintln(" - not a directory\n");
+            DebugPrintln(" - not a directory");
             return false;
         }
     }
@@ -51,15 +51,15 @@ bool FSWebServer::checkDir(const char *dirname)
 
 bool FSWebServer::begin()
 {
-    DebugPrintln("\nList the files of webserver: ");
+    DebugPrintln("List the files of webserver: ");
     File root = m_filesystem->open("/setup", "r");
     if (!root)
     {
-        DebugPrintln("Failed to open /setup directory. Create new folder\n");
+        DebugPrintln("Failed to open /setup directory. Create new folder");
         m_filesystem->mkdir("/setup");
         ESP.restart();
     }
-    m_fsOK = checkDir("/", 2);
+    m_fsOK = checkDir("/");
 
     // Backward compatibility, move config.json to new path
     root = m_filesystem->open("/config.json", "r");
@@ -68,7 +68,7 @@ bool FSWebServer::begin()
         m_filesystem->rename("/config.json", CONFIG_FILE);
     }
 
-#ifdef ESP_FS_WS_EDIT
+#if ESP_FS_WS_EDIT
     webserver->on("/status", HTTP_GET, std::bind(&FSWebServer::handleStatus, this));
     webserver->on("/list", HTTP_GET, std::bind(&FSWebServer::handleFileList, this));
     webserver->on("/edit", HTTP_GET, std::bind(&FSWebServer::handleGetEdit, this));
@@ -78,7 +78,7 @@ bool FSWebServer::begin()
     webserver->onNotFound(std::bind(&FSWebServer::handleRequest, this));
     webserver->on("/favicon.ico", HTTP_GET, std::bind(&FSWebServer::replyOK, this));
     webserver->on("/", HTTP_GET, std::bind(&FSWebServer::handleIndex, this));
-#ifdef ESP_FS_WS_SETUP
+#if ESP_FS_WS_SETUP
     webserver->on("/setup", HTTP_GET, std::bind(&FSWebServer::handleSetup, this));
 #endif
     webserver->on("/scan", HTTP_GET, std::bind(&FSWebServer::handleScanNetworks, this));
@@ -406,7 +406,7 @@ void FSWebServer::handleScanNetworks()
 }
 
 
-#ifdef ESP_FS_WS_SETUP
+#if ESP_FS_WS_SETUP
 
 bool FSWebServer::clearOptions() {
     File file = m_filesystem->open(CONFIG_FILE, "r");
@@ -557,7 +557,8 @@ void FSWebServer::removeWhiteSpaces(String& str) {
 
 void FSWebServer::handleSetup()
 {
-#ifdef INCLUDE_SETUP_HTM
+    DebugPrintln("handleSetup");
+#if ESP_FS_WS_SETUP_HTM
     webserver->sendHeader(PSTR("Content-Encoding"), "gzip");
     webserver->send_P(200, "text/html", SETUP_HTML, SETUP_HTML_SIZE);
 #else
@@ -759,7 +760,7 @@ const char *FSWebServer::getContentType(const char *filename)
 }
 
 // edit page, in usefull in some situation, but if you need to provide only a web interface, you can disable
-#ifdef ESP_FS_WS_EDIT
+#if ESP_FS_WS_EDIT
 
 /*
     Return the list of files in the directory specified by the "dir" query string parameter.
@@ -948,7 +949,7 @@ void FSWebServer::handleFileDelete()
 */
 void FSWebServer::handleGetEdit()
 {
-#ifdef INCLUDE_EDIT_HTM
+#if ESP_FS_WS_EDIT_HTM
     webserver->sendHeader(PSTR("Content-Encoding"), "gzip");
     webserver->send_P(200, "text/html", edit_htm_gz, EDIT_HTML_SIZE);
 #else

--- a/src/esp-fs-webserver.cpp
+++ b/src/esp-fs-webserver.cpp
@@ -42,9 +42,9 @@ bool FSWebServer::checkDir(const char *dirname)
             return false;
         }
     }
-#if DEBUG_MODE_WS
+#if INFO_MODE_WS
     // List all files saved in the selected filesystem
-    PrintDir(*m_filesystem, DBG_OUTPUT_PORT, dirname);    
+    PrintDir(*m_filesystem, INFO_OUTPUT_PORT, dirname);    
 #endif
     return true;
 }
@@ -136,9 +136,9 @@ IPAddress FSWebServer::startAP()
     m_dnsServer.start(53, "*", ip);
     WiFi.begin();   //???
     ip = WiFi.softAPIP();
-    Serial.print(F("\nAP mode.\nServer IP address: "));
-    Serial.println(ip);
-    Serial.println();
+    InfoPrintln(F("AP mode."));
+    InfoPrint(F("Server IP address: "));
+    InfoPrintln(ip);
     return ip;
 }
 
@@ -165,15 +165,15 @@ IPAddress FSWebServer::startWiFi(uint32_t timeout, bool apFlag, CallbackF fn )
         WiFi.mode(WIFI_STA);
         WiFi.begin(_ssid, _pass);
         uint32_t startTime = millis();
-        Serial.print(F("Connecting to "));
-        Serial.println(_ssid);
+        InfoPrint(F("Connecting to "));
+        InfoPrintln(_ssid);
         while ( (WiFi.status() != WL_CONNECTED) && (timeout > 0 ) )
         {
             // execute callback function during wifi connection
             if (fn != nullptr)
                 fn();
             delay(250);
-            Serial.print(".");
+            InfoPrint(".");
             // If no connection after a while break
             if (millis() - startTime > timeout)
                 break;
@@ -213,7 +213,6 @@ void FSWebServer::handleRequest()
         replyToCLient(ERROR, PSTR(FS_INIT_ERROR));
         return;
     }
-
     String _url = WebServerClass::urlDecode(webserver->uri());
     // First try to find and return the requested file from the filesystem,
     // and if it fails, return a 404 page with debug information
@@ -270,22 +269,22 @@ void FSWebServer::doWifiConnection()
         webserver->send(200, "text/plain", resp);
 
         delay(500);
-        Serial.println("Disconnect from current WiFi network");
+        InfoPrintln("Disconnect from current WiFi network");
         WiFi.disconnect();
     }
 
-    if (ssid.length() && pass.length())
-    {
+    if (ssid.length())
+    {   // pass could be empty
         // Try to connect to new ssid
-        Serial.print("\nConnecting to ");
-        Serial.println(ssid);
+        InfoPrint("Connecting to ");
+        InfoPrintln(ssid);
         WiFi.begin(ssid.c_str(), pass.c_str());
 
         uint32_t beginTime = millis();
         while (WiFi.status() != WL_CONNECTED)
         {
-            delay(500);
-            Serial.print("*.*");
+            delay(250);
+            InfoPrint(".");
             if (millis() - beginTime > m_timeout)
                 break;
         }
@@ -294,8 +293,8 @@ void FSWebServer::doWifiConnection()
         {
             // WiFi.softAPdisconnect();
             IPAddress ip = WiFi.localIP();
-            Serial.print("\nConnected to Wifi! IP address: ");
-            Serial.println(ip);
+            InfoPrint("Connected to Wifi! IP address: ");
+            InfoPrintln(ip);
             String serverLoc = F("http://");
             for (int i = 0; i < 4; i++)
                 serverLoc += i ? "." + String(ip[i]) : String(ip[i]);

--- a/src/esp-fs-webserver.cpp
+++ b/src/esp-fs-webserver.cpp
@@ -351,25 +351,30 @@ void FSWebServer::doWifiConnection()
 #endif
             }
             else {
-                #if defined(ESP8266)
-                struct station_config stationConf;
-                wifi_station_get_config_default(&stationConf);
-                // Clear previuos configuration
-                memset(&stationConf, 0, sizeof(stationConf));
-                wifi_station_set_config(&stationConf);
-#elif defined(ESP32)
-                wifi_config_t stationConf;
-                esp_wifi_get_config(WIFI_IF_STA, &stationConf);
-                // Clear previuos configuration
-                memset(&stationConf, 0, sizeof(stationConf));
-                esp_wifi_set_config(WIFI_IF_STA, &stationConf);
-#endif
+                this->clearWifiCredentials();                
             }
         }
         else
             webserver->send(500, "text/plain", "Connection error, maybe the password is wrong?");
     }
     webserver->send(500, "text/plain", "Wrong credentials provided");
+}
+
+void FSWebServer::clearWifiCredentials()
+{
+#if defined(ESP8266)
+    struct station_config stationConf;
+    wifi_station_get_config_default(&stationConf);
+    // Clear previuos configuration
+    memset(&stationConf, 0, sizeof(stationConf));
+    wifi_station_set_config(&stationConf);
+#elif defined(ESP32)
+    wifi_config_t stationConf;
+    esp_wifi_get_config(WIFI_IF_STA, &stationConf);
+    // Clear previuos configuration
+    memset(&stationConf, 0, sizeof(stationConf));
+    esp_wifi_set_config(WIFI_IF_STA, &stationConf);
+#endif
 }
 
 void FSWebServer::setCrossOrigin()

--- a/src/esp-fs-webserver.cpp
+++ b/src/esp-fs-webserver.cpp
@@ -42,9 +42,9 @@ bool FSWebServer::checkDir(const char *dirname)
             return false;
         }
     }
-#if INFO_MODE_WS
+#if ESP_FS_WS_INFO_MODE
     // List all files saved in the selected filesystem
-    PrintDir(*m_filesystem, INFO_OUTPUT_PORT, dirname);    
+    PrintDir(*m_filesystem, ESP_FS_WS_INFO_OUTPUT, dirname);    
 #endif
     return true;
 }
@@ -65,7 +65,7 @@ bool FSWebServer::begin()
     root = m_filesystem->open("/config.json", "r");
     if(root) {
         root.close();
-        m_filesystem->rename("/config.json", CONFIG_FILE);
+        m_filesystem->rename("/config.json", ESP_FS_WS_CONFIG_FILE);
     }
 
 #if ESP_FS_WS_EDIT
@@ -408,10 +408,10 @@ void FSWebServer::handleScanNetworks()
 #if ESP_FS_WS_SETUP
 
 bool FSWebServer::clearOptions() {
-    File file = m_filesystem->open(CONFIG_FILE, "r");
+    File file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "r");
     if (file) {
         file.close();
-        m_filesystem->remove(CONFIG_FILE);
+        m_filesystem->remove(ESP_FS_WS_CONFIG_FILE);
         return true;
     }
     return false;
@@ -491,7 +491,7 @@ void FSWebServer::addJavascript(const char* script, bool overWrite) {
 }
 
 void FSWebServer::addDropdownList(const char *label, const char** array, size_t size) {
-    File file = m_filesystem->open(CONFIG_FILE, "r");
+    File file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "r");
     int sz = file.size() * 1.33;
     int docSize = max(sz, 2048);
     DynamicJsonDocument doc((size_t)docSize);
@@ -526,7 +526,7 @@ void FSWebServer::addDropdownList(const char *label, const char** array, size_t 
         arr.add(array[i]);
     }
 
-    file = m_filesystem->open(CONFIG_FILE, "w");
+    file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "w");
     if (serializeJsonPretty(doc, file) == 0)
     {
         DebugPrintln(F("Failed to write to file"));

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -262,7 +262,7 @@ private:
     File m_uploadFile;
     bool m_fsOK = false;
     bool m_apmode = false;
-    char *m_apWebpage = (char *)"/setup";
+    const char *m_apWebpage = "/setup";
     uint32_t m_timeout = 10000;
 
     // Default handler for all URIs not defined above, use it to read files from filesystem

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -68,15 +68,12 @@ enum
 
 class FSWebServer
 {
-
     using CallbackF = std::function<void(void)>;
 
 public:
-    WebServerClass *webserver;
-
     FSWebServer(fs::FS &fs, WebServerClass &server);
 
-    bool begin(const char *path = nullptr);
+    bool begin();
 
     void run();
 
@@ -84,13 +81,21 @@ public:
 
     void addHandler(const Uri &uri, WebServerClass::THandlerFunction handler);
 
-    void setCaptiveWebage(const char *url);
+    void setAPWebPage(const char *url);
+    void setAP(const char *ssid, const char *psk);
 
-    IPAddress setAPmode(const char *ssid, const char *psk);
+    IPAddress startAP();
 
-    IPAddress startWiFi(uint32_t timeout, const char *apSSID, const char *apPsw, CallbackF fn = nullptr);
+    IPAddress startWiFi(
+        uint32_t timeout            // if 0 - do not wait for wifi connections
+        , bool apFlag = false       // if true, start AP only if no credentials was found
+        , CallbackF fn = nullptr    // execute callback function during wifi connection
+        );
 
-    WebServerClass *getRequest();
+    void clearWifiCredentials();
+
+    WebServerClass* getWebServer(){ return webserver; }
+    uint32_t getTimeout() const { return m_timeout; }
 
 #ifdef INCLUDE_SETUP_HTM
 #define MIN_F -3.4028235E+38
@@ -254,21 +259,21 @@ public:
 #endif
 
 private:
-
-    // char m_basePath[16];
+    WebServerClass *webserver;
     UpdateServerClass m_httpUpdater;
     DNSServer m_dnsServer;
     fs::FS *m_filesystem;
     File m_uploadFile;
     bool m_fsOK = false;
     bool m_apmode = false;
-    const char *m_apWebpage = "/setup";
+    String m_apWebpage; //default "/setup";
+    String m_apSsid;
+    String m_apPsk;
     uint32_t m_timeout = 10000;
 
     // Default handler for all URIs not defined above, use it to read files from filesystem
     bool checkDir(const char *dirname, uint8_t levels);
     void doWifiConnection();
-    void clearWifiCredentials();
     void doRestart();
     void replyOK();
     void getIpAddress();

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -8,31 +8,35 @@
 #include <FS.h>
 
 //default values
-#define ESP_FS_WS_EDIT      //has edit methods
-#define INCLUDE_EDIT_HTM    //included from progmem
-
-#define ESP_FS_WS_SETUP     //gas setup methods
-#define INCLUDE_SETUP_HTM   //included from progmem
-
-#define DBG_OUTPUT_PORT Serial
-#define DEBUG_MODE_WS 0
-
-#ifdef ESP_FS_WS_USER_H
-    //user can undef symbols
-    #include <esp_fs_ws_user.h>
+#ifndef ESP_FS_WS_EDIT
+    #define ESP_FS_WS_EDIT              1   //has edit methods
+    #ifndef ESP_FS_WS_EDIT_HTM
+        #define ESP_FS_WS_EDIT_HTM      1   //included from progmem
+    #endif
+#endif
+#ifndef ESP_FS_WS_SETUP
+    #define ESP_FS_WS_SETUP             1   //has setup methods
+    #ifndef ESP_FS_WS_SETUP_HTM
+        #define ESP_FS_WS_SETUP_HTM     1   //included from progmem
+    #endif
+#endif
+#ifndef DBG_OUTPUT_PORT
+    #define DBG_OUTPUT_PORT             Serial
+#endif
+#ifndef DEBUG_MODE_WS
+    #define DEBUG_MODE_WS               0
 #endif
 
-#ifdef ESP_FS_WS_EDIT
-    #ifdef INCLUDE_EDIT_HTM
+#if ESP_FS_WS_EDIT
+    #if ESP_FS_WS_EDIT_HTM
         #include "edit_htm.h"
     #endif
 #endif
-
-#ifdef ESP_FS_WS_SETUP
+#if ESP_FS_WS_SETUP
     #define ARDUINOJSON_USE_LONG_LONG 1
     #include <ArduinoJson.h>
     #define CONFIG_FILE "/setup/config.json"
-    #ifdef INCLUDE_SETUP_HTM
+    #if ESP_FS_WS_SETUP_HTM
         #include "setup_htm.h"
     #endif
 #endif
@@ -56,15 +60,17 @@ using UpdateServerClass = HTTPUpdateServer;
 #include <DNSServer.h>
 
 #if DEBUG_MODE_WS
+#pragma message("DEBUG_MODE_WS")
 #define DebugPrint(x) DBG_OUTPUT_PORT.print(x)
 #define DebugPrintln(x) DBG_OUTPUT_PORT.println(x)
 #define DebugPrintf(fmt, ...) DBG_OUTPUT_PORT.printf(fmt, ##__VA_ARGS__)
-#define DebugPrintf_P(fmt, ...) DBG_OUTPUT_PORT.printf_P(fmt, ##__VA_ARGS__)
+//#define DebugPrintf_P(fmt, ...) DBG_OUTPUT_PORT.printf_P(fmt, ##__VA_ARGS__)
+#define DebugPrintf_P(x, ...) ((void)0)
 #else
-#define DebugPrint(x)
-#define DebugPrintln(x)
-#define DebugPrintf(x, ...)
-#define DebugPrintf_P(x, ...)
+#define DebugPrint(x) ((void)0)
+#define DebugPrintln(x) ((void)0)
+#define DebugPrintf(x, ...) ((void)0)
+#define DebugPrintf_P(x, ...) ((void)0)
 #endif
 
 enum
@@ -107,10 +113,11 @@ public:
 
     void clearWifiCredentials();
 
-    WebServerClass* getWebServer(){ return webserver; }
-    uint32_t getTimeout() const { return m_timeout; }
+    inline WebServerClass* getWebServer(){ return webserver; }
+    inline uint32_t getTimeout() const { return m_timeout; }
+    inline bool getAPMode() const { return m_apmode; }
 
-#ifdef ESP_FS_WS_SETUP
+#if ESP_FS_WS_SETUP
     #define MIN_F -3.4028235E+38
     #define MAX_F 3.4028235E+38
 
@@ -292,7 +299,7 @@ private:
     void getIpAddress();
     void handleRequest();
 
-#ifdef ESP_FS_WS_SETUP
+#if ESP_FS_WS_SETUP
     bool optionToFile(const char* filename, const char* str, bool overWrite = false);
     void removeWhiteSpaces(String& str);
     void handleSetup();
@@ -310,7 +317,7 @@ private:
     bool captivePortal();
 
     // edit page, in usefull in some situation, but if you need to provide only a web interface, you can disable
-#ifdef ESP_FS_WS_EDIT
+#if ESP_FS_WS_EDIT
     void handleGetEdit();
     void handleFileCreate();
     void handleFileDelete();

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -22,18 +22,18 @@
     #endif
 #endif
 
-#ifndef DBG_OUTPUT_PORT
-    #define DBG_OUTPUT_PORT             Serial
+#ifndef ESP_FS_WS_DEBUG_OUTPUT
+    #define ESP_FS_WS_DEBUG_OUTPUT      Serial
 #endif
-#ifndef DEBUG_MODE_WS
-    #define DEBUG_MODE_WS               0
+#ifndef ESP_FS_WS_DEBUG_MODE
+    #define ESP_FS_WS_DEBUG_MODE        0
 #endif
 
-#ifndef INFO_OUTPUT_PORT
-    #define INFO_OUTPUT_PORT            Serial
+#ifndef ESP_FS_WS_INFO_OUTPUT
+    #define ESP_FS_WS_INFO_OUTPUT       Serial
 #endif
-#ifndef INFO_MODE_WS
-    #define INFO_MODE_WS                1
+#ifndef ESP_FS_WS_INFO_MODE
+    #define ESP_FS_WS_INFO_MODE         1
 #endif
 
 #if ESP_FS_WS_EDIT
@@ -44,7 +44,7 @@
 #if ESP_FS_WS_SETUP
     #define ARDUINOJSON_USE_LONG_LONG 1
     #include <ArduinoJson.h>
-    #define CONFIG_FILE "/setup/config.json"
+    #define ESP_FS_WS_CONFIG_FILE "/setup/config.json"
     #if ESP_FS_WS_SETUP_HTM
         #include "setup_htm.h"
     #endif
@@ -68,11 +68,11 @@
 #endif
 #include <DNSServer.h>
 
-#if DEBUG_MODE_WS
-    #define DebugPrint(...) DBG_OUTPUT_PORT.print(__VA_ARGS__)
-    #define DebugPrintln(...) DBG_OUTPUT_PORT.println(__VA_ARGS__)
-    #define DebugPrintf(...) DBG_OUTPUT_PORT.printf(__VA_ARGS__)
-    #define DebugPrintf_P(...) DBG_OUTPUT_PORT.printf_P(__VA_ARGS__)
+#if ESP_FS_WS_DEBUG_MODE
+    #define DebugPrint(...) ESP_FS_WS_DEBUG_OUTPUT.print(__VA_ARGS__)
+    #define DebugPrintln(...) ESP_FS_WS_DEBUG_OUTPUT.println(__VA_ARGS__)
+    #define DebugPrintf(...) ESP_FS_WS_DEBUG_OUTPUT.printf(__VA_ARGS__)
+    #define DebugPrintf_P(...) ESP_FS_WS_DEBUG_OUTPUT.printf_P(__VA_ARGS__)
 #else
     #define DebugPrint(...) ((void)0)
     #define DebugPrintln(...) ((void)0)
@@ -80,9 +80,9 @@
     #define DebugPrintf_P(...) ((void)0)
 #endif
 
-#if INFO_MODE_WS
-    #define InfoPrint(...) INFO_OUTPUT_PORT.print(__VA_ARGS__)
-    #define InfoPrintln(...) INFO_OUTPUT_PORT.println(__VA_ARGS__)
+#if ESP_FS_WS_INFO_MODE
+    #define InfoPrint(...) ESP_FS_WS_INFO_OUTPUT.print(__VA_ARGS__)
+    #define InfoPrintln(...) ESP_FS_WS_INFO_OUTPUT.println(__VA_ARGS__)
 #else
     #define InfoPrint(...) ((void)0)
     #define InfoPrintln(...) ((void)0)
@@ -136,7 +136,7 @@ public:
     #define MIN_F -3.4028235E+38
     #define MAX_F 3.4028235E+38
 
-    inline const char* configFile() {return CONFIG_FILE; }
+    inline const char* configFile() {return ESP_FS_WS_CONFIG_FILE; }
 
     bool clearOptions();
     void addHTML(const char* html, const char* id, bool overWrite = false) ;
@@ -168,7 +168,7 @@ public:
     inline void addOption(const char *label, T val, bool hidden = false,
                     double d_min = MIN_F, double d_max = MAX_F, double step = 1.0)
     {
-        File file = m_filesystem->open(CONFIG_FILE, "r");
+        File file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "r");
         int sz = file.size() * 1.33;
         int docSize = max(sz, 2048);
         DynamicJsonDocument doc((size_t)docSize);
@@ -221,7 +221,7 @@ public:
             doc[key] = static_cast<T>(val);
         }
 
-        file = m_filesystem->open(CONFIG_FILE, "w");
+        file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "w");
         if (serializeJsonPretty(doc, file) == 0)
         {
             DebugPrintln(F("Failed to write to file"));
@@ -235,7 +235,7 @@ public:
     template <typename T>
     bool getOptionValue(const char *label, T &var)
     {
-        File file = m_filesystem->open(CONFIG_FILE, "r");
+        File file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "r");
         DynamicJsonDocument doc(file.size() * 1.33);
         if (file)
         {
@@ -264,7 +264,7 @@ public:
     template <typename T>
     bool saveOptionValue(const char *label, T val)
     {
-        File file = m_filesystem->open(CONFIG_FILE, "w");
+        File file = m_filesystem->open(ESP_FS_WS_CONFIG_FILE, "w");
         DynamicJsonDocument doc(file.size() * 1.33);
 
         if (file)

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -268,6 +268,7 @@ private:
     // Default handler for all URIs not defined above, use it to read files from filesystem
     bool checkDir(const char *dirname, uint8_t levels);
     void doWifiConnection();
+    void clearWifiCredentials();
     void doRestart();
     void replyOK();
     void getIpAddress();

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -14,17 +14,26 @@
         #define ESP_FS_WS_EDIT_HTM      1   //included from progmem
     #endif
 #endif
+
 #ifndef ESP_FS_WS_SETUP
     #define ESP_FS_WS_SETUP             1   //has setup methods
     #ifndef ESP_FS_WS_SETUP_HTM
         #define ESP_FS_WS_SETUP_HTM     1   //included from progmem
     #endif
 #endif
+
 #ifndef DBG_OUTPUT_PORT
     #define DBG_OUTPUT_PORT             Serial
 #endif
 #ifndef DEBUG_MODE_WS
     #define DEBUG_MODE_WS               0
+#endif
+
+#ifndef INFO_OUTPUT_PORT
+    #define INFO_OUTPUT_PORT            Serial
+#endif
+#ifndef INFO_MODE_WS
+    #define INFO_MODE_WS                1
 #endif
 
 #if ESP_FS_WS_EDIT
@@ -42,35 +51,41 @@
 #endif
 
 #if defined(ESP8266)
-#include <ESP8266WiFi.h>
-#include <ESP8266WebServer.h>
-#include <ESP8266mDNS.h>
-#include <ESP8266HTTPUpdateServer.h> // from Arduino core, OTA update via webbrowser
-using WebServerClass = ESP8266WebServer;
-using UpdateServerClass = ESP8266HTTPUpdateServer;
+    #include <ESP8266WiFi.h>
+    #include <ESP8266WebServer.h>
+    #include <ESP8266mDNS.h>
+    #include <ESP8266HTTPUpdateServer.h> // from Arduino core, OTA update via webbrowser
+    using WebServerClass = ESP8266WebServer;
+    using UpdateServerClass = ESP8266HTTPUpdateServer;
 #elif defined(ESP32)
-#include <esp_wifi.h>
-#include <WebServer.h>
-#include <WiFi.h>
-#include <ESPmDNS.h>
-#include <HTTPUpdateServer.h> // from Arduino core, OTA update via webbrowser
-using WebServerClass = WebServer;
-using UpdateServerClass = HTTPUpdateServer;
+    #include <esp_wifi.h>
+    #include <WebServer.h>
+    #include <WiFi.h>
+    #include <ESPmDNS.h>
+    #include <HTTPUpdateServer.h> // from Arduino core, OTA update via webbrowser
+    using WebServerClass = WebServer;
+    using UpdateServerClass = HTTPUpdateServer;
 #endif
 #include <DNSServer.h>
 
 #if DEBUG_MODE_WS
-#pragma message("DEBUG_MODE_WS")
-#define DebugPrint(x) DBG_OUTPUT_PORT.print(x)
-#define DebugPrintln(x) DBG_OUTPUT_PORT.println(x)
-#define DebugPrintf(fmt, ...) DBG_OUTPUT_PORT.printf(fmt, ##__VA_ARGS__)
-//#define DebugPrintf_P(fmt, ...) DBG_OUTPUT_PORT.printf_P(fmt, ##__VA_ARGS__)
-#define DebugPrintf_P(x, ...) ((void)0)
+    #define DebugPrint(...) DBG_OUTPUT_PORT.print(__VA_ARGS__)
+    #define DebugPrintln(...) DBG_OUTPUT_PORT.println(__VA_ARGS__)
+    #define DebugPrintf(...) DBG_OUTPUT_PORT.printf(__VA_ARGS__)
+    #define DebugPrintf_P(...) DBG_OUTPUT_PORT.printf_P(__VA_ARGS__)
 #else
-#define DebugPrint(x) ((void)0)
-#define DebugPrintln(x) ((void)0)
-#define DebugPrintf(x, ...) ((void)0)
-#define DebugPrintf_P(x, ...) ((void)0)
+    #define DebugPrint(...) ((void)0)
+    #define DebugPrintln(...) ((void)0)
+    #define DebugPrintf(...) ((void)0)
+    #define DebugPrintf_P(...) ((void)0)
+#endif
+
+#if INFO_MODE_WS
+    #define InfoPrint(...) INFO_OUTPUT_PORT.print(__VA_ARGS__)
+    #define InfoPrintln(...) INFO_OUTPUT_PORT.println(__VA_ARGS__)
+#else
+    #define InfoPrint(...) ((void)0)
+    #define InfoPrintln(...) ((void)0)
 #endif
 
 enum


### PR DESCRIPTION
Hello,

I started adapting the library for a project that has the following requirements:
 - setting credentials if they do not exist
 - once the network is set, do not start the AP at startup in case it cannot connect to the network
For example, in case of a power failure, the router will start more difficult and the application will be stuck in AP mode
- option to restore the default values (from the web page or button)

I also modified:
- the names of the defines so that there is a lower risk of being equal to defines from other libraries
- defines with values 0/1 that can be added in platformio,ini with build_flags
- option to completely remove serial port calls

Kind regards,
Bogdan