### PR TITLE
Add option for requiring HTTP basic authentication on all pages.

### DIFF
--- a/src/esp-fs-webserver.cpp
+++ b/src/esp-fs-webserver.cpp
@@ -151,6 +151,13 @@ void FSWebServer::setAuthentication(const char* user, const char* pswd) {
     strcpy(m_pagePswd, pswd);
 }
 
+/*
+ Enable the flag which turns on basic authentication for all pages
+ */
+void FSWebServer::requireAuthentication(bool require)
+{
+    m_authAll = require;
+}
 
 void FSWebServer::setAP(const char* ssid, const char* psk)
 {
@@ -301,6 +308,14 @@ bool FSWebServer::captivePortal()
 void FSWebServer::handleRequest()
 {
     log_debug("handleRequest");
+    
+    // Check if authentication for all routes is turned on,
+    // and credentials are present:
+    if (m_authAll && m_pageUser != nullptr) {
+        if(!this->authenticate(m_pageUser, m_pagePswd))
+            return this->requestAuthentication();
+    }
+    
     if (!m_fsOK) {
         replyToCLient(ERROR, PSTR(FS_INIT_ERROR));
         return;

--- a/src/esp-fs-webserver.h
+++ b/src/esp-fs-webserver.h
@@ -179,6 +179,12 @@ public:
       Enable authenticate for /setup webpage
     */
     void setAuthentication(const char* user, const char* pswd);
+    
+    /*
+      Enable authentication for other pages, too.
+      Call setAuthentication first.
+    */
+    void requireAuthentication(bool require);
 
 #if ESP_FS_WS_SETUP
     /*
@@ -244,6 +250,7 @@ private:
     FsInfoCallbackF getFsInfo;
     char*           m_pageUser = nullptr;
     char*           m_pagePswd = nullptr;
+    bool            m_authAll = false;
     DNSServer*      m_dnsServer  = nullptr;
     fs::FS*         m_filesystem = nullptr;
     File            m_uploadFile;


### PR DESCRIPTION
Hi @cotestatnt . Firstly, I wanted to say many thanks for authoring and sharing this library. It has been very useful to me in creating easy-to-code REST HTTP IoT Smart Home devices with ESP8266- one of my current interests.

For the purposes of my project, I wanted to require HTTP basic authentication on all registered server routes for security purposes. While you have already usefully implemented `FSWebServer::setAuthentication(const char* user, const char* pswd)`, this currently only restricts access to the `/setup` and `/edit` pages. 

To resolve this need, I have introduced a new function, `FSWebServer::requireAuthentication(bool require)`. A user of the `esp-fs-webserver` library calling this function can enable authentication checks for every request, on all routes. I have implemented this by modification of the `FSWebServer::handleRequest()` function.

The user simply runs `myWebServer.requireAuthentication(true)` along with the original `setAuthentication()` call to turn this feature on from their script. It can be turned off again just as easily, by passing `false`. For example:

```c++
// (exclude other code from simpleServer.ino example to keep this short)
FSWebServer myWebServer(FILESYSTEM, 80);
const char* http_user = "admin";
const char* http_password = "change-me";

void setup(){
  // <snip, extra stuff>
  myWebServer.setAuthentication(http_user, http_password);
  myWebServer.requireAuthentication(true);
  myWebServer.begin();
}
```

It would be amazing if you felt able to include these changes in your library for other users to enjoy. Please review this pull request, and let me know if you require any further changes to introduce this new feature.