### PR TITLE
docs: fix config file name references

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -80,7 +80,7 @@ Config file and callback:
 
 ```cpp
 File getConfigFile(const char* mode);
-const char* getConfiFileName();
+const char* getConfigFileName();
 bool clearConfigFile();
 void setConfigSavedCallback(ConfigSavedCallbackF callback);
 ```

--- a/docs/SetupAndWiFi.md
+++ b/docs/SetupAndWiFi.md
@@ -53,7 +53,7 @@ server.getOptionValue("Option 2", option2);
 
 ## Config file: read/write
 
-- Full path: `server.getConfiFileName()`
+- Full path: `server.getConfigFileName()`
 - File access: `server.getConfigFile("r")` / `server.getConfigFile("w")`
 - Reset config: `server.clearConfigFile()`
 

--- a/examples/customHTML/customHTML.ino
+++ b/examples/customHTML/customHTML.ino
@@ -80,7 +80,7 @@ bool startFilesystem() {
 
 ////////////////////  Load application options from filesystem  ////////////////////
 bool loadOptions() {
-  if (FILESYSTEM.exists(server.getConfiFileName())) {
+  if (FILESYSTEM.exists(server.getConfigFileName())) {
     // Test "options" values
     server.getOptionValue(LED_LABEL, ledPin);
     server.getOptionValue(BOOL_LABEL, boolVar);

--- a/examples/customOptions/customOptions.ino
+++ b/examples/customOptions/customOptions.ino
@@ -91,7 +91,7 @@ bool startFilesystem() {
 
 ////////////////////  Load application options from filesystem  ////////////////////
 bool loadOptions() {
-  if (FILESYSTEM.exists(server.getConfiFileName())) {
+  if (FILESYSTEM.exists(server.getConfigFileName())) {
     server.getOptionValue(LED_LABEL, ledPin);
     server.getOptionValue(BOOL_LABEL, boolVar);
     server.getOptionValue(BOOL_LABEL2, boolVar2);

--- a/examples/localRFID/webserver.hpp
+++ b/examples/localRFID/webserver.hpp
@@ -169,7 +169,7 @@ bool startWebServer(bool clear = false) {
   }
 
   if (clear) {
-    LittleFS.remove(myWebServer.getConfiFileName());
+    LittleFS.remove(myWebServer.getConfigFileName());
   }
 
   // Try to connect to WiFi (will start AP if not connected after timeout)

--- a/examples/mysqlRFID/webserver_impl.h
+++ b/examples/mysqlRFID/webserver_impl.h
@@ -200,7 +200,7 @@ void handleMainPage() {
 
 ////////////////////  Load application options from filesystem  ////////////////////
 bool loadOptions() {
-  if (LittleFS.exists(myWebServer.getConfiFileName())) {
+  if (LittleFS.exists(myWebServer.getConfigFileName())) {
     myWebServer.getOptionValue(MY_SQL_HOST, dbHost);
     myWebServer.getOptionValue(MY_SQL_PORT, dbPort);
     myWebServer.getOptionValue(MY_SQL_DB, database);
@@ -215,7 +215,7 @@ bool loadOptions() {
     return true;
   }
   else
-    Serial.printf("File \"%s\" not exist\n", myWebServer.getConfiFileName());
+    Serial.printf("File \"%s\" not exist\n", myWebServer.getConfigFileName());
   return false;
 }
 
@@ -232,7 +232,7 @@ bool startWebServer(bool clear = false) {
   }
 
   if (clear) {
-    LittleFS.remove(myWebServer.getConfiFileName());
+    LittleFS.remove(myWebServer.getConfigFileName());
   }
 
   // Load configuration (if not present, default will be created when webserver will start)

--- a/examples/simpleServer/simpleServer.ino
+++ b/examples/simpleServer/simpleServer.ino
@@ -27,7 +27,7 @@ bool startFilesystem() {
 
 ////////////////////////////  Load custom options //////////////////////////////////////
 bool loadApplicationConfig() {
-  if (LittleFS.exists(server.getConfiFileName())) {
+  if (LittleFS.exists(server.getConfigFileName())) {
     // Test "options" values
     server.getOptionValue("Test int variable", testInt);
     server.getOptionValue("Test float variable", testFloat);

--- a/examples/withWebSocket/withWebSocket.ino
+++ b/examples/withWebSocket/withWebSocket.ino
@@ -93,7 +93,7 @@ bool startFilesystem() {
 
 ////////////////////  Load and save application configuration from filesystem  ////////////////////
 bool loadApplicationConfig() {
-  if (FILESYSTEM.exists(server.getConfiFileName())) {
+  if (FILESYSTEM.exists(server.getConfigFileName())) {
     server.getOptionValue("Option 1", optionString);
     server.getOptionValue("Option 2", optionULong);
     server.getOptionValue("LED Pin", ledPin);

--- a/keywords.txt
+++ b/keywords.txt
@@ -36,7 +36,7 @@ getServerIP         KEYWORD2
 isAccessPointMode   KEYWORD2
 getConfigFile       KEYWORD2
 clearConfigFile     KEYWORD2
-getConfiFileName    KEYWORD2
+getConfigFileName    KEYWORD2
 setSetupPageTitle   KEYWORD2
 setLogoBase64       KEYWORD2
 getTaskHandler      KEYWORD2

--- a/pio_examples/customOptions/src/customOptions.ino
+++ b/pio_examples/customOptions/src/customOptions.ino
@@ -235,7 +235,7 @@ bool startFilesystem() {
 
 ////////////////////  Load application options from filesystem  ////////////////////
 bool loadOptions() {
-  if (FILESYSTEM.exists(server.getConfiFileName())) {
+  if (FILESYSTEM.exists(server.getConfigFileName())) {
     server.getOptionValue(LED_LABEL, ledPin);
     server.getOptionValue(BOOL_LABEL, boolVar);
     server.getOptionValue(BOOL_LABEL2, boolVar2);

--- a/pio_examples/esp32-p4/src/withWebSocket.cpp
+++ b/pio_examples/esp32-p4/src/withWebSocket.cpp
@@ -90,7 +90,7 @@ bool startFilesystem() {
 
 ////////////////////  Load and save application configuration from filesystem  ////////////////////
 bool loadApplicationConfig() {
-    if (FILESYSTEM.exists(server.getConfiFileName())) {
+    if (FILESYSTEM.exists(server.getConfigFileName())) {
         server.getOptionValue("Option 1", optionString);
         server.getOptionValue("Option 2", optionULong);
         server.closeSetupConfiguration();  // Close configuration to free resources

--- a/pio_examples/simpleServer/src/simpleServer.ino
+++ b/pio_examples/simpleServer/src/simpleServer.ino
@@ -30,7 +30,7 @@ uint8_t wifiStatus = WL_IDLE_STATUS;  // WiFi status variable to track connectio
 
 ////////////////////////////  Load custom options //////////////////////////////////////
 bool loadApplicationConfig() {
-  if (LittleFS.exists(server.getConfiFileName())) {
+  if (LittleFS.exists(server.getConfigFileName())) {
     // Test "options" values
     server.getOptionValue("Test int variable", testInt);
     server.getOptionValue("Test float variable", testFloat);

--- a/pio_examples/withWebSocket/src/withWebSocket.ino
+++ b/pio_examples/withWebSocket/src/withWebSocket.ino
@@ -92,7 +92,7 @@ bool startFilesystem() {
 
 ////////////////////  Load and save application configuration from filesystem  ////////////////////
 bool loadApplicationConfig() {
-  if (FILESYSTEM.exists(server.getConfiFileName())) {
+  if (FILESYSTEM.exists(server.getConfigFileName())) {
     server.getOptionValue("Option 1", optionString);
     server.getOptionValue("Option 2", optionULong);
     server.getOptionValue("LED Pin", ledPin);


### PR DESCRIPTION
## Summary
- update docs, examples, and Arduino keywords from `getConfiFileName()` to `getConfigFileName()`
- leave the existing `FSWebServer` implementation unchanged

## Why
`src/FSWebServer.h` currently defines `getConfigFileName()`, but the docs/examples still referenced the old misspelled name from #78. This keeps the usage examples aligned with the current source method.

## Checks
- `rg -n "getConfiFileName|getConfigFileName" . -S`
- `python3` text check confirming `getConfigFileName` exists in `src/FSWebServer.h` and stale `getConfiFileName` is absent from the changed docs/examples
- `git diff --check`

I could not run PlatformIO/Arduino builds because neither `pio`, `platformio`, nor `arduino-cli` is installed in this environment.
